### PR TITLE
Update maybe_run_tick lock usage

### DIFF
--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -196,8 +196,7 @@ DECLARE
 BEGIN
   SELECT * INTO v_game FROM public.games WHERE id = p_game FOR UPDATE;
   IF v_game.next_tick_at <= now() THEN
-    PERFORM pg_try_advisory_xact_lock(hashtext(v_game.id::text));
-    IF FOUND THEN
+    IF pg_try_advisory_xact_lock(hashtext(v_game.id::text)) THEN
       PERFORM public.tick(v_game.id);
     END IF;
   END IF;


### PR DESCRIPTION
## Summary
- replace FOUND check with advisory lock boolean return in `maybe_run_tick`

## Testing
- `npm test` *(fails: Could not read package.json)*
- `supabase db reset` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685a397031b083218c52d69c4651fa57