### PR TITLE
Add tick assertions

### DIFF
--- a/supabase/tests/tick.test.sql
+++ b/supabase/tests/tick.test.sql
@@ -3,17 +3,37 @@
 
 BEGIN;
 
--- Plan the tests.
-SELECT plan(1);
+-- Plan the tests. We will run three assertions.
+SELECT plan(3);
 
--- Run the test.
--- This is a very basic test that just checks if the function runs without errors.
+-- Store the current next_tick_at to compare after running tick().
+CREATE TEMP TABLE tmp_old_tick AS
+  SELECT next_tick_at FROM public.games
+  WHERE id = '00000000-0000-0000-0000-000000000001';
+
+-- Run the tick() function and ensure it succeeds.
 SELECT lives_ok(
   $$ SELECT public.tick('00000000-0000-0000-0000-000000000001') $$,
   'tick() function should run without errors for the seed game'
 );
 
+-- Verify an event row was inserted for the game.
+SELECT is(
+  (SELECT count(*) FROM public.events
+   WHERE game_id = '00000000-0000-0000-0000-000000000001'
+     AND type = 'tick'),
+  1,
+  'tick() inserts an event'
+);
+
+-- Verify next_tick_at advanced relative to the stored value.
+SELECT ok(
+  (SELECT next_tick_at FROM public.games WHERE id = '00000000-0000-0000-0000-000000000001') >
+  (SELECT next_tick_at FROM tmp_old_tick),
+  'next_tick_at is scheduled in the future'
+);
+
 -- Finish the tests.
 SELECT * FROM finish();
 
-ROLLBACK; 
+ROLLBACK;


### PR DESCRIPTION
## Summary
- improve pgTAP tests for `tick()` to confirm an event is logged and `next_tick_at` updates

## Testing
- `npm test` *(fails: ENOENT: no such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_685a397ed3608321a3d79a427f7035ea