### PR TITLE
Add AP store + fetch on mount

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -1,13 +1,14 @@
-import React from 'react';
-import Map from './components/Map';
-import OrdersPanel from './components/OrdersPanel';
-import APBar from './components/APBar';
-import { useGame } from './hooks/useGame';
+import React from 'react'
+import Map from './components/Map'
+import OrdersPanel from './components/OrdersPanel'
+import APBar from './components/APBar'
+import { useGame } from './hooks/useGame'
 
 function App() {
-  // Hardcoded gameId for now. In a real app, this would come from the URL or a lobby system.
-  const gameId = '00000000-0000-0000-0000-000000000001';
-  const { lockOrders } = useGame(gameId);
+  // Hardcoded IDs for now. In a real app these would come from auth/lobby.
+  const gameId = '00000000-0000-0000-0000-000000000001'
+  const playerId = '00000000-0000-0000-0000-000000000001'
+  const { lockOrders } = useGame(gameId, playerId)
 
   return (
     <div style={{ display: 'flex', flexDirection: 'column', height: '100vh' }}>

--- a/client/src/components/APBar.tsx
+++ b/client/src/components/APBar.tsx
@@ -1,13 +1,12 @@
-import React from 'react';
-import { useGameStore } from '../store';
+import React from 'react'
+import { useGameStore } from '../store'
 
 const APBar = () => {
-  const armies = useGameStore((state) => state.armies); // Using 'armies' as a placeholder for AP
+  const { ap, apCap } = useGameStore((state) => ({ ap: state.ap, apCap: state.apCap }))
 
   return (
     <div style={{ border: '1px solid black', padding: '1rem', marginTop: '1rem' }}>
-      <h3>Action Points: {armies} / 24</h3>
-      {/* TODO: Replace placeholder with actual AP from store */}
+      <h3>Action Points: {ap} / {apCap}</h3>
     </div>
   );
 };

--- a/client/src/hooks/useGame.ts
+++ b/client/src/hooks/useGame.ts
@@ -2,12 +2,30 @@
 // such as fetching the initial game state, subscribing to real-time updates,
 // and providing functions to interact with the game (e.g., submit orders).
 
-import { useEffect } from 'react';
-import { supabase } from '../supabase';
-import { useGameStore } from '../store';
+import { useEffect } from 'react'
+import { supabase } from '../supabase'
+import { useGameStore } from '../store'
 
-export const useGame = (gameId: string) => {
-  const store = useGameStore();
+export const useGame = (gameId: string, playerId: string) => {
+  const { setAp } = useGameStore()
+
+  // Fetch current Action Points on mount
+  useEffect(() => {
+    if (!playerId) return
+
+    const fetchAp = async () => {
+      const { data, error } = await supabase.rpc('current_ap', {
+        p_player: playerId,
+      })
+      if (error) {
+        console.error('Error fetching current AP:', error)
+      } else if (typeof data === 'number') {
+        setAp(data)
+      }
+    }
+
+    fetchAp()
+  }, [playerId, setAp])
 
   useEffect(() => {
     if (!gameId) return;
@@ -46,7 +64,7 @@ export const useGame = (gameId: string) => {
     return () => {
       supabase.removeChannel(channel);
     };
-  }, [gameId, store]);
+  }, [gameId]);
 
   // Expose functions to interact with the game
   const lockOrders = async () => {

--- a/client/src/store.ts
+++ b/client/src/store.ts
@@ -1,13 +1,15 @@
 import { create } from 'zustand'
 
 interface GameState {
-  // Define state properties here
-  // e.g., territories, players, orders
-  armies: number
-  increaseArmies: (by: number) => void
+  ap: number
+  apCap: number
+  setAp: (ap: number) => void
+  setApCap: (cap: number) => void
 }
 
 export const useGameStore = create<GameState>()((set) => ({
-  armies: 0,
-  increaseArmies: (by) => set((state) => ({ armies: state.armies + by })),
-})) 
+  ap: 0,
+  apCap: 24,
+  setAp: (ap) => set({ ap }),
+  setApCap: (cap) => set({ apCap: cap }),
+}))


### PR DESCRIPTION
## Summary
- store ap and apCap values in zustand
- grab current AP via RPC on lobby mount
- display AP values in APBar

## Testing
- `npm test` *(fails: missing script)*
- `npx supabase db reset` *(fails: requires package installation)*

------
https://chatgpt.com/codex/tasks/task_e_685a3d021df48321bd4e234a06a0eeb5