### PR TITLE
Populate territories from Supabase

### DIFF
--- a/client/src/components/Map.tsx
+++ b/client/src/components/Map.tsx
@@ -1,16 +1,25 @@
 import React from 'react';
+import { useGameStore } from '../store';
 
-// This will be a simple SVG map.
-// For a real game, you would use a library like d3 or a more complex SVG.
-
+// Simple placeholder map rendering territories as circles
 const Map = () => {
+  const territories = useGameStore((s) => s.territories);
+
   return (
     <svg width="800" height="600" viewBox="0 0 800 600" style={{ border: '1px solid black' }}>
       <rect width="800" height="600" fill="#eee" />
-      <text x="50%" y="50%" dominantBaseline="middle" textAnchor="middle">
-        Map Placeholder
-      </text>
-      {/* TODO: Render territories from game state */}
+      {territories.map((t, idx) => {
+        const x = 50 + (idx % 8) * 90;
+        const y = 50 + Math.floor(idx / 8) * 90;
+        return (
+          <g key={t.id} transform={`translate(${x}, ${y})`}>
+            <circle r="20" fill="#ccc" stroke="#000" />
+            <text y="35" textAnchor="middle" fontSize="10">
+              {t.name}
+            </text>
+          </g>
+        );
+      })}
     </svg>
   );
 };

--- a/client/src/hooks/useGame.ts
+++ b/client/src/hooks/useGame.ts
@@ -7,7 +7,7 @@ import { supabase } from '../supabase';
 import { useGameStore } from '../store';
 
 export const useGame = (gameId: string) => {
-  const store = useGameStore();
+  const { setTerritories } = useGameStore();
 
   useEffect(() => {
     if (!gameId) return;
@@ -21,9 +21,15 @@ export const useGame = (gameId: string) => {
 
       if (error) {
         console.error('Error fetching initial state:', error);
-      } else {
-        // Here you would transform the data and update the store
-        console.log('Initial state:', data);
+      } else if (data) {
+        setTerritories(
+          data.map((t) => ({
+            id: t.territory_id as string,
+            name: t.territory_name as string,
+            owner: (t.owner_id as string) ?? null,
+            armies: t.armies as number,
+          }))
+        );
       }
     };
 
@@ -46,7 +52,7 @@ export const useGame = (gameId: string) => {
     return () => {
       supabase.removeChannel(channel);
     };
-  }, [gameId, store]);
+  }, [gameId, setTerritories]);
 
   // Expose functions to interact with the game
   const lockOrders = async () => {

--- a/client/src/store.ts
+++ b/client/src/store.ts
@@ -1,13 +1,22 @@
 import { create } from 'zustand'
 
-interface GameState {
-  // Define state properties here
-  // e.g., territories, players, orders
+export interface Territory {
+  id: string
+  name: string
+  owner: string | null
   armies: number
+}
+
+interface GameState {
+  armies: number
+  territories: Territory[]
   increaseArmies: (by: number) => void
+  setTerritories: (t: Territory[]) => void
 }
 
 export const useGameStore = create<GameState>()((set) => ({
   armies: 0,
+  territories: [],
   increaseArmies: (by) => set((state) => ({ armies: state.armies + by })),
-})) 
+  setTerritories: (territories) => set({ territories }),
+}))


### PR DESCRIPTION
## Summary
- extend Zustand store with a `territories` array
- fetch `game_state` rows in `useGame` and store territories
- render placeholder circles for each territory on the map

## Testing
- `npm test` *(fails: Missing script)*
- `npx supabase db reset` *(fails: Cannot connect to Docker daemon)*

------
https://chatgpt.com/codex/tasks/task_e_685a3cfcf3588321a67b5f0b104db1ef