### PR TITLE
Implement basic territory rendering

### DIFF
--- a/client/src/components/Map.tsx
+++ b/client/src/components/Map.tsx
@@ -1,16 +1,27 @@
 import React from 'react';
+import { useGameStore } from '../store';
 
 // This will be a simple SVG map.
 // For a real game, you would use a library like d3 or a more complex SVG.
 
 const Map = () => {
+  const territories = useGameStore((s) => s.territories);
+
   return (
     <svg width="800" height="600" viewBox="0 0 800 600" style={{ border: '1px solid black' }}>
       <rect width="800" height="600" fill="#eee" />
-      <text x="50%" y="50%" dominantBaseline="middle" textAnchor="middle">
-        Map Placeholder
-      </text>
-      {/* TODO: Render territories from game state */}
+      {territories.map((t, i) => {
+        const x = 50 + (i % 10) * 70;
+        const y = 50 + Math.floor(i / 10) * 70;
+        return (
+          <g key={t.id} transform={`translate(${x}, ${y})`}>
+            <circle r={20} fill="#ccc" stroke="#333" />
+            <text textAnchor="middle" dy=".35em" style={{ fontSize: '8px' }}>
+              {t.name}
+            </text>
+          </g>
+        );
+      })}
     </svg>
   );
 };

--- a/client/src/hooks/useGame.ts
+++ b/client/src/hooks/useGame.ts
@@ -21,9 +21,14 @@ export const useGame = (gameId: string, playerId: string) => {
 
       if (error) {
         console.error('Error fetching initial state:', error);
-      } else {
-        // Here you would transform the data and update the store
-        console.log('Initial state:', data);
+      } else if (data) {
+        const territories = data.map((row) => ({
+          id: row.territory_id as string,
+          name: row.territory_name as string,
+          owner: (row.owner_name as string) || null,
+          armies: row.armies as number,
+        }));
+        store.setTerritories(territories);
       }
     };
 

--- a/client/src/store.ts
+++ b/client/src/store.ts
@@ -11,18 +11,29 @@ export interface Order {
   executed_at: string | null
 }
 
+export interface Territory {
+  id: string
+  name: string
+  owner: string | null
+  armies: number
+}
+
 interface GameState {
   armies: number
   orders: Order[]
+  territories: Territory[]
   setOrders: (orders: Order[]) => void
   addOrder: (order: Order) => void
+  setTerritories: (territories: Territory[]) => void
   increaseArmies: (by: number) => void
 }
 
 export const useGameStore = create<GameState>()((set) => ({
   armies: 0,
   orders: [],
+  territories: [],
   setOrders: (orders) => set(() => ({ orders })),
   addOrder: (order) => set((state) => ({ orders: [...state.orders, order] })),
+  setTerritories: (territories) => set(() => ({ territories })),
   increaseArmies: (by) => set((state) => ({ armies: state.armies + by })),
 }))


### PR DESCRIPTION
## Summary
- extend Zustand store with a `territories` array
- fetch territories in `useGame` from `game_state`
- render territories in `Map` as placeholder circles
- remove the old placeholder text

## Testing
- `npm test` *(fails: missing script)*
- `npx supabase db reset` *(fails: Docker not running)*

------
https://chatgpt.com/codex/tasks/task_e_685a9f02413483218bf3677681bfa668