### PR TITLE
Implement AP tracking in store

### DIFF
--- a/client/src/components/APBar.tsx
+++ b/client/src/components/APBar.tsx
@@ -2,14 +2,14 @@ import React from 'react';
 import { useGameStore } from '../store';
 
 const APBar = () => {
-  const armies = useGameStore((state) => state.armies); // Using 'armies' as a placeholder for AP
+  const ap = useGameStore((state) => state.ap);
+  const apCap = useGameStore((state) => state.apCap);
 
   return (
     <div style={{ border: '1px solid black', padding: '1rem', marginTop: '1rem' }}>
-      <h3>Action Points: {armies} / 24</h3>
-      {/* TODO: Replace placeholder with actual AP from store */}
+      <h3>Action Points: {ap} / {apCap}</h3>
     </div>
   );
 };
 
-export default APBar; 
+export default APBar;

--- a/client/src/hooks/useGame.ts
+++ b/client/src/hooks/useGame.ts
@@ -50,6 +50,30 @@ export const useGame = (gameId: string, playerId: string) => {
 
     fetchOrders();
 
+    const fetchAp = async () => {
+      const { data: ap, error: apErr } = await supabase.rpc('current_ap', {
+        p_player: playerId,
+      });
+      if (apErr) {
+        console.error('Error fetching AP:', apErr);
+      } else if (typeof ap === 'number') {
+        store.setAp(ap);
+      }
+
+      const { data: capData, error: capErr } = await supabase
+        .from('players')
+        .select('ap_cap')
+        .eq('id', playerId)
+        .single();
+      if (capErr) {
+        console.error('Error fetching AP cap:', capErr);
+      } else if (capData) {
+        store.setApCap(capData.ap_cap as number);
+      }
+    };
+
+    fetchAp();
+
     // Subscribe to real-time updates
     const eventsChannel = supabase
       .channel(`game:${gameId}`)
@@ -91,6 +115,3 @@ export const useGame = (gameId: string, playerId: string) => {
     const { error } = await supabase.rpc('lock_orders', { p_game_id: gameId });
     if (error) console.error('Error locking orders:', error);
   };
-
-  return { lockOrders };
-}; 

--- a/client/src/store.ts
+++ b/client/src/store.ts
@@ -19,21 +19,25 @@ export interface Territory {
 }
 
 interface GameState {
-  armies: number
+  ap: number
+  apCap: number
   orders: Order[]
   territories: Territory[]
   setOrders: (orders: Order[]) => void
   addOrder: (order: Order) => void
   setTerritories: (territories: Territory[]) => void
-  increaseArmies: (by: number) => void
+  setAp: (ap: number) => void
+  setApCap: (cap: number) => void
 }
 
 export const useGameStore = create<GameState>()((set) => ({
-  armies: 0,
+  ap: 0,
+  apCap: 0,
   orders: [],
   territories: [],
   setOrders: (orders) => set(() => ({ orders })),
   addOrder: (order) => set((state) => ({ orders: [...state.orders, order] })),
   setTerritories: (territories) => set(() => ({ territories })),
-  increaseArmies: (by) => set((state) => ({ armies: state.armies + by })),
+  setAp: (ap) => set(() => ({ ap })),
+  setApCap: (cap) => set(() => ({ apCap: cap })),
 }))


### PR DESCRIPTION
## Summary
- keep player Action Points in the Zustand store
- fetch current AP on game start via `current_ap` RPC
- show AP values in the Action Point bar

## Testing
- `npm test` *(fails: ENOENT no package.json)*
- `yes | npx supabase db reset` *(fails: cannot connect to Docker daemon)*

------
https://chatgpt.com/codex/tasks/task_e_685aa0f1d69c8321ae8afa0f37c08a0f